### PR TITLE
main starts when doc is ready

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import { attach_filepickers } from './file_picker';
 import 'bootstrap/js/dist/modal'; // note that this depends on jQuery
 
-attach_filepickers();
+
+$(document).ready(attach_filepickers)


### PR DESCRIPTION
I had to add this because my particular rails app that was using this library needed to ensure this loads after the dom is fully rendered by rails.