### PR TITLE
Dynamically calculate acceptable modal content height

### DIFF
--- a/src/components/file_picker.vue
+++ b/src/components/file_picker.vue
@@ -505,8 +505,9 @@ export default {
   /* End Bulma Modal */
 
   .modal-body {
-    height: 400px;
+    height: auto !important;
     overflow-y: auto;
+    max-height: calc(100vh - 360px) !important;
   }
 
   .glyphicon.spinning {


### PR DESCRIPTION
This PR fixes a bug where users with lots of favorites or users on smaller screens wouldn't be able to see the modal footer. The modal content height is now automatically calculated.