### PR TITLE
Fix mobile modal view

### DIFF
--- a/src/components/file_picker.vue
+++ b/src/components/file_picker.vue
@@ -434,7 +434,6 @@ export default {
 
   .modal-content,
   .modal-card {
-    margin: 0 20px;
     max-height: calc(100vh - 160px);
     overflow: auto;
     position: relative;


### PR DESCRIPTION
Remove unnecessary margins that were messing up mobile view of the file picker. 

Correct view:
![image](https://user-images.githubusercontent.com/6081892/79403530-2ead0b00-7f5d-11ea-8caa-b550fc102c60.png)
