### PR TITLE
Spacing between icons and text

### DIFF
--- a/src/components/file_picker.vue
+++ b/src/components/file_picker.vue
@@ -29,7 +29,7 @@
                         v-for="entry in fs_favorites"
                         v-on:click="menuClicked(entry, $event)"
                         v-bind:key="entry.title"
-                      ><span class="fa fa-folder">&nbsp;</span>{{entry.title}}</a>
+                      ><span class="fa fa-folder mr-2">&nbsp;</span>{{entry.title}}</a>
                     </div>
                   </div>
                 </div>
@@ -112,7 +112,7 @@ export default {
   },
   methods: {
     iconClasses: function(entry) {
-      return (entry.type === 'd') ? 'fa fa-folder' : 'fa fa-file';
+      return (entry.type === 'd') ? 'fa fa-folder mr-2' : 'fa fa-file mr-2';
     },
     iconStyles: function(entry) {
       return (entry.type === 'd') ? 'color: #eccb00;' : 'color: #e6e6e6;';


### PR DESCRIPTION
Currently the text sticks on the icons. With some margin using the bootstrap variable this looks personally a lot better.

Before:

![image](https://github.com/user-attachments/assets/b3747a30-0485-4b9f-a13e-f5b23b538634)


After:

![image](https://github.com/user-attachments/assets/50c5f455-fe55-4780-92d2-d1b5d27ed4c7)
